### PR TITLE
items-vote and get implementations

### DIFF
--- a/api/src/auth/mod.rs
+++ b/api/src/auth/mod.rs
@@ -26,47 +26,31 @@ pub fn get_auth_layer(pool: DbPool, session_layer: MySessionManagerLayer) -> MyA
 }
 
 pub(crate) trait AuthenticationExt {
+  /// Get the user from the session store if one exists
+  fn get_user_from_session(&self) -> Option<User>;
   /// Get the user from the session store, or else return an Error
   ///
   /// Return Ok(user) if the caller is authenticated as the given user.
-  /// Return Err(ApiError::Forbidden) if caller is not authenticated.
-  fn get_user_from_session(&self) -> ApiResult<User>;
-  /// Assert that the caller is logged in and not banned
-  ///
-  /// Return Ok(user) if the caller is authenticated as the given user.
-  /// Return Err(ApiError::Forbidden) if caller is not authenticated.
-  /// Return Err(ApiError::Unauthorized) if caller is authenticated but with non-matching username.
-  fn if_authenticated_get_user(&self, username: &Username) -> ApiResult<User>;
-  /// Return whether the caller is logged in
-  fn is_authenticated_and_not_banned(&self) -> bool;
-  /// Return whether the caller is logged in as username
-  fn is_username_authenticated_and_not_banned(&self, username: &Username) -> bool;
+  /// Return Err(ApiError::Unauthorized) if caller is not logged in.
+  /// Return Err(ApiError::Forbidden) if caller is banned.
+  fn get_assert_user_from_session(&self) -> ApiResult<User>;
+  /// Return whether the caller is logged in and not banned
+  fn am_authenticated_and_not_banned(&self) -> bool;
 }
 
 impl AuthenticationExt for AuthSession {
-  fn get_user_from_session(&self) -> ApiResult<User> {
-    let user = self.user.as_ref().ok_or(ApiError::UnauthorizedPleaseLogin)?.clone().0;
+  fn get_user_from_session(&self) -> Option<User> { self.user.clone().map(|u| u.0) }
+
+  fn get_assert_user_from_session(&self) -> ApiResult<User> {
+    let user = self.get_user_from_session().ok_or(ApiError::UnauthorizedPleaseLogin)?.clone();
     if user.banned {
       return Err(ApiError::ForbiddenBanned);
     }
     Ok(user)
   }
 
-  fn if_authenticated_get_user(&self, username: &Username) -> ApiResult<User> {
-    let user = self.get_user_from_session()?;
-    if user.username == *username {
-      Ok(user)
-    } else {
-      Err(ApiError::ForbiddenUsernameDoesNotMatchSession)
-    }
-  }
-
-  fn is_authenticated_and_not_banned(&self) -> bool {
+  fn am_authenticated_and_not_banned(&self) -> bool {
     self.user.as_ref().map(|user| !user.0.banned).unwrap_or(false)
-  }
-
-  fn is_username_authenticated_and_not_banned(&self, username: &Username) -> bool {
-    self.is_authenticated_and_not_banned() && self.user.as_ref().unwrap().0.username == *username
   }
 }
 

--- a/api/src/auth/mod.rs
+++ b/api/src/auth/mod.rs
@@ -35,8 +35,10 @@ pub(crate) trait AuthenticationExt {
   /// Return Err(ApiError::Forbidden) if caller is not authenticated.
   /// Return Err(ApiError::Unauthorized) if caller is authenticated but with non-matching username.
   fn if_authenticated_get_user(&self, username: &Username) -> ApiResult<User>;
+  /// Return whether the caller is logged in
+  fn is_authenticated_and_not_banned(&self) -> bool;
   /// Return whether the caller is logged in as username
-  fn is_authenticated_and_not_banned(&self, username: &Username) -> bool;
+  fn is_username_authenticated_and_not_banned(&self, username: &Username) -> bool;
 }
 
 impl AuthenticationExt for AuthSession {
@@ -57,8 +59,11 @@ impl AuthenticationExt for AuthSession {
     }
   }
 
-  fn is_authenticated_and_not_banned(&self, username: &Username) -> bool {
-    self.user.as_ref().map(|user| user.0.username == *username).unwrap_or(false)
-      && !self.user.as_ref().unwrap().0.banned
+  fn is_authenticated_and_not_banned(&self) -> bool {
+    self.user.as_ref().map(|user| !user.0.banned).unwrap_or(false)
+  }
+
+  fn is_username_authenticated_and_not_banned(&self, username: &Username) -> bool {
+    self.is_authenticated_and_not_banned() && self.user.as_ref().unwrap().0.username == *username
   }
 }

--- a/api/src/auth/mod.rs
+++ b/api/src/auth/mod.rs
@@ -26,7 +26,7 @@ pub fn get_auth_layer(pool: DbPool, session_layer: MySessionManagerLayer) -> MyA
 }
 
 pub(crate) trait AuthenticationExt {
-  /// Get the user from the session store, if one exists
+  /// Get the user from the session store, or else return an Error
   ///
   /// Return Ok(user) if the caller is authenticated as the given user.
   /// Return Err(ApiError::Forbidden) if caller is not authenticated.

--- a/api/src/auth/users.rs
+++ b/api/src/auth/users.rs
@@ -50,7 +50,7 @@ impl AuthnBackend for AuthBackend {
   }
 
   async fn get_user(&self, username: &UserId<Self>) -> Result<Option<Self::User>, Self::Error> {
-    let user = db::queries::users::get_user(&self.db, username).await?;
+    let user = db::queries::users::get_assert_user(&self.db, username).await?;
     Ok(Some(UserWrapper(user)))
   }
 }

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -51,6 +51,9 @@ pub enum ApiError {
   /// The client submitted an incorrect password
   #[status(StatusCode::UNAUTHORIZED)] // 401
   UnauthorizedIncorrectPassword,
+  /// The client submitted a change to a dead item or comment
+  #[status(StatusCode::FORBIDDEN)] // 403
+  ForbiddenDead,
   /// The client submitted an incorrect password
   #[status(StatusCode::FORBIDDEN)] // 403
   ForbiddenUsernameDoesNotMatchSession,
@@ -81,7 +84,8 @@ impl std::fmt::Display for ApiError {
       ApiError::BadRequest(e) => write!(f, "Invalid request submitted: {e}"),
       ApiError::UnauthorizedPleaseLogin => write!(f, "Unauthorized: please log in",),
       ApiError::UnauthorizedIncorrectPassword => write!(f, "Unauthorized: Incorrect password"),
-      ApiError::ForbiddenBanned => write!(f, "Unauthorized: User is banned"),
+      ApiError::ForbiddenDead => write!(f, "Forbidden: item or comment is dead"),
+      ApiError::ForbiddenBanned => write!(f, "Forbidden: User is banned"),
       ApiError::ForbiddenUsernameDoesNotMatchSession =>
         write!(f, "Forbidden: provided username does not match session"),
       ApiError::ForbiddenModeratorRequired => write!(f, "Forbidden: Moderator only"),

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -23,6 +23,7 @@ pub(crate) type ApiResult<T> = Result<T, ApiError>;
 pub use self::error::ApiError;
 // export payloads and responses
 pub use self::routes::users::*;
+pub use self::routes::items::*;
 
 pub const MINIMUM_KARMA_TO_DOWNVOTE: i32 = 10; // todo(config)
 pub const COMMENTS_PER_PAGE: usize = 10; // todo(config)

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -20,10 +20,11 @@ use self::{auth::get_auth_layer, sessions::create_migrate_session_layer};
 
 pub(crate) type ApiResult<T> = Result<T, ApiError>;
 
-pub use self::error::ApiError;
 // export payloads and responses
-pub use self::routes::users::*;
-pub use self::routes::items::*;
+pub use self::{
+  error::ApiError,
+  routes::{items::*, users::*},
+};
 
 pub const MINIMUM_KARMA_TO_DOWNVOTE: i32 = 10; // todo(config)
 pub const COMMENTS_PER_PAGE: usize = 10; // todo(config)

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -25,6 +25,7 @@ pub use self::error::ApiError;
 pub use self::routes::users::*;
 
 pub const MINIMUM_KARMA_TO_DOWNVOTE: i32 = 10; // todo(config)
+pub const COMMENTS_PER_PAGE: usize = 10; // todo(config)
 
 pub async fn app(pool: DbPool, session_key: Key) -> ApiResult<Router> {
   let session_layer = create_migrate_session_layer(pool.clone(), session_key).await;

--- a/api/src/routes/items/get.rs
+++ b/api/src/routes/items/get.rs
@@ -22,6 +22,84 @@ pub async fn get_item(
 ) -> ApiResult<Json<Item>> {
   trace!("get_item called with id: {id}");
   let is_authenticated = auth_session.is_authenticated_and_not_banned();
+    // Extract the `show_dead_comments` value from `auth_user`
+    let show_dead_comments = todo!("Extract the value from `auth_user.show_dead`");
+
+     // Prepare the `comments_db_query` based on `show_dead_comments`
+    let mut comments_db_query = todo!("Create a struct or HashMap for `comments_db_query`");
+    comments_db_query.parent_item_id = id;
+    comments_db_query.is_parent = true;
+    if !show_dead_comments {
+        comments_db_query.dead = false;
+    }   
+
+    // Fetch the item, comments, and total number of comments concurrently
+    let (item, comments, total_num_of_comments) = tokio::join!(
+        todo!("Fetch the item using `ItemModel.find_one`"),
+        todo!("Fetch the comments using `CommentModel.find` with pagination and sorting"),
+        todo!("Count the total number of comments using `CommentModel.count_documents`"),
+    );
+
+    // Check if the item exists
+    let item = match item {
+        Some(item) => item,
+        None => return Err(ApiError::NotFound),
+    };
+
+    // If the user is not signed in
+    if !is_authenticated {
+        return Ok(Json(Item {
+            success: true,
+            item,
+            comments,
+            is_more_comments: total_num_of_comments > todo!("Calculate the value"),
+        }));
+    }
+
+    // If the user is signed in
+    let (vote_doc, favorite_doc, hidden_doc, comment_vote_docs) = tokio::join!(
+        todo!("Fetch the vote document using `UserVoteModel.find_one`"),
+        todo!("Fetch the favorite document using `UserFavoriteModel.find_one`"),
+        todo!("Fetch the hidden document using `UserHiddenModel.find_one`"),
+        todo!("Fetch the comment vote documents using `UserVoteModel.find`"),
+    );
+
+    // Set up all item and user relations
+    item.voted_on_by_user = vote_doc.is_some();
+    item.unvote_expired = todo!("Calculate the unvote expiration based on `vote_doc` and `config.hrs_until_unvote_expires`");
+    item.favorited_by_user = favorite_doc.is_some();
+    item.hidden_by_user = hidden_doc.is_some();
+
+    // Check if the item is still able to be edited/deleted
+    if item.by == auth_session.username {
+        let has_edit_and_delete_expired = todo!("Calculate the edit and delete expiration based on `item.created`, `config.hrs_until_edit_and_delete_expires`, and `item.comment_count`");
+        item.edit_and_delete_expired = has_edit_and_delete_expired;
+    }
+
+    // Prepare to get item comments
+    let user_comment_votes: Vec<_> = comment_vote_docs.iter().map(|doc| doc.id).collect();
+
+    // Update each comment recursively
+    fn update_comment(comment: &mut Comment, auth_session: &AuthSession, user_comment_votes: &[Uuid], comment_vote_docs: &[CommentVoteDoc]) {
+        // TODO: Implement the `update_comment` function
+    }
+
+    // Call the `update_comment` function for each comment
+    for comment in &mut comments {
+        update_comment(comment, &auth_session, &user_comment_votes, &comment_vote_docs);
+    }
+
+    Ok(Json(Item {
+        success: true,
+        item,
+        comments,
+        is_more_comments: total_num_of_comments > todo!("Calculate the value"),
+    }))
+
+
+  todo!()
+}
+
   // mark show_dead_comments
   // create comments query
   // get item, comments, total comments number
@@ -33,5 +111,3 @@ pub async fn get_item(
   // // When auth is implemented, we will want to return different user data, per the caller's
   // auth. info!("found user: {user:?}");
   // Ok(Json(user))
-  todo!()
-}

--- a/api/src/routes/items/get.rs
+++ b/api/src/routes/items/get.rs
@@ -1,113 +1,64 @@
+use std::f32::consts::E;
+
+use axum::extract::Query;
+use db::{Page, PasswordHash};
+use serde_json::Number;
+
 use super::*;
 
 #[utoipa::path(
   get,
   path = "/items/{id}",
-  params( ("id" = String, Path, example = Uuid::new_v4) ),
-  responses(
-    (status = 422, description = "Invalid id"),
-    (status = 404, description = "User not found"),
-    (status = 200, description = "Success", body = GetItemResponse),// todo(define reduced UserResponse body)
-  ),
+  params( ("id" = String, Path, example = Uuid::new_v4),
+          ("page" = i32, Query, example = Page::default) ),
+  responses( (status = 422, description = "Invalid id"),
+             (status = 404, description = "User not found"),
+             (status = 200, description = "Success", body = GetItemResponse) ),
   )]
 /// Get item.
 ///
 /// If user is authenticated, ...todo
 ///
 /// ref: https://github.com/thor314/zkhn/blob/main/rest-api/routes/items/api.js#L92
+/// ref: https://github.com/thor314/zkhn/blob/main/rest-api/routes/items/index.js#L52
 pub async fn get_item(
   State(state): State<SharedState>,
   Path(id): Path<Uuid>,
+  Query(page): Query<Page>,
   auth_session: AuthSession,
-) -> ApiResult<Json<Item>> {
-  trace!("get_item called with id: {id}");
-  let is_authenticated = auth_session.is_authenticated_and_not_banned();
-    // Extract the `show_dead_comments` value from `auth_user`
-    let show_dead_comments = todo!("Extract the value from `auth_user.show_dead`");
+) -> ApiResult<Json<GetItemResponse>> {
+  trace!("get_item called with id: {id} and page: {page:?}");
+  page.validate(&())?;
 
-     // Prepare the `comments_db_query` based on `show_dead_comments`
-    let mut comments_db_query = todo!("Create a struct or HashMap for `comments_db_query`");
-    comments_db_query.parent_item_id = id;
-    comments_db_query.is_parent = true;
-    if !show_dead_comments {
-        comments_db_query.dead = false;
-    }   
+  let user = auth_session.get_user_from_session().unwrap_or_else(|_| User::new_logged_out());
+  let (item, (comments, total_comments)) = tokio::try_join!(
+    db::queries::items::get_item(&state.pool, id),
+    db::queries::comments::get_comments_page(&state.pool, id, page, user.show_dead),
+  )?;
 
-    // Fetch the item, comments, and total number of comments concurrently
-    let (item, comments, total_num_of_comments) = tokio::join!(
-        todo!("Fetch the item using `ItemModel.find_one`"),
-        todo!("Fetch the comments using `CommentModel.find` with pagination and sorting"),
-        todo!("Count the total number of comments using `CommentModel.count_documents`"),
-    );
-
-    // Check if the item exists
-    let item = match item {
-        Some(item) => item,
-        None => return Err(ApiError::NotFound),
-    };
-
-    // If the user is not signed in
-    if !is_authenticated {
-        return Ok(Json(Item {
-            success: true,
-            item,
-            comments,
-            is_more_comments: total_num_of_comments > todo!("Calculate the value"),
-        }));
-    }
-
-    // If the user is signed in
-    let (vote_doc, favorite_doc, hidden_doc, comment_vote_docs) = tokio::join!(
-        todo!("Fetch the vote document using `UserVoteModel.find_one`"),
-        todo!("Fetch the favorite document using `UserFavoriteModel.find_one`"),
-        todo!("Fetch the hidden document using `UserHiddenModel.find_one`"),
-        todo!("Fetch the comment vote documents using `UserVoteModel.find`"),
-    );
-
-    // Set up all item and user relations
-    item.voted_on_by_user = vote_doc.is_some();
-    item.unvote_expired = todo!("Calculate the unvote expiration based on `vote_doc` and `config.hrs_until_unvote_expires`");
-    item.favorited_by_user = favorite_doc.is_some();
-    item.hidden_by_user = hidden_doc.is_some();
-
-    // Check if the item is still able to be edited/deleted
-    if item.by == auth_session.username {
-        let has_edit_and_delete_expired = todo!("Calculate the edit and delete expiration based on `item.created`, `config.hrs_until_edit_and_delete_expires`, and `item.comment_count`");
-        item.edit_and_delete_expired = has_edit_and_delete_expired;
-    }
-
-    // Prepare to get item comments
-    let user_comment_votes: Vec<_> = comment_vote_docs.iter().map(|doc| doc.id).collect();
-
-    // Update each comment recursively
-    fn update_comment(comment: &mut Comment, auth_session: &AuthSession, user_comment_votes: &[Uuid], comment_vote_docs: &[CommentVoteDoc]) {
-        // TODO: Implement the `update_comment` function
-    }
-
-    // Call the `update_comment` function for each comment
-    for comment in &mut comments {
-        update_comment(comment, &auth_session, &user_comment_votes, &comment_vote_docs);
-    }
-
-    Ok(Json(Item {
-        success: true,
-        item,
-        comments,
-        is_more_comments: total_num_of_comments > todo!("Calculate the value"),
-    }))
-
-
-  todo!()
+  let get_item_response = GetItemResponse::new(item, comments, total_comments);
+  // backlog(refactor) - matching off janky empty username is mega code smell
+  if user.username.0.is_empty() {
+    // Unauthenticated user
+    Ok(Json(get_item_response))
+  } else {
+    // Authenticated user
+    // get user's itemVotes, itemFavorites, itemHiddens, and commentVotes, and update item_response
+    // accordingly
+    //
+    // let (item_votes, item_favorites, item_hiddens, comment_votes) = tokio::try_join!(todo)
+    Ok(Json(get_item_response))
+  }
 }
 
-  // mark show_dead_comments
-  // create comments query
-  // get item, comments, total comments number
-  //
-  // let user = db::queries::users::get_item(pool, &)
-  //   .await?
-  //   .ok_or(ApiError::DbEntryNotFound("that user does not exist".to_string()))?;
-  // // todo(auth): currently, we return the whole user.
-  // // When auth is implemented, we will want to return different user data, per the caller's
-  // auth. info!("found user: {user:?}");
-  // Ok(Json(user))
+// mark show_dead_comments
+// create comments query
+// get item, comments, total comments number
+//
+// let user = db::queries::users::get_item(pool, &)
+//   .await?
+//   .ok_or(ApiError::DbEntryNotFound("that user does not exist".to_string()))?;
+// // todo(auth): currently, we return the whole user.
+// // When auth is implemented, we will want to return different user data, per the caller's
+// auth. info!("found user: {user:?}");
+// Ok(Json(user))

--- a/api/src/routes/items/get.rs
+++ b/api/src/routes/items/get.rs
@@ -11,8 +11,8 @@ use super::*;
   ),
   )]
 /// Get item.
-/// 
-/// 
+///
+///
 ///
 /// ref get_public: https://github.com/thor314/zkhn/blob/main/rest-api/routes/users/api.js#L223
 /// ref get_private: https://github.com/thor314/zkhn/blob/main/rest-api/routes/users/api.js#L244

--- a/api/src/routes/items/get.rs
+++ b/api/src/routes/items/get.rs
@@ -30,7 +30,7 @@ pub async fn get_item(
   trace!("get_item called with id: {id} and page: {page:?}");
   page.validate(&())?;
 
-  let user = auth_session.get_user_from_session().unwrap_or_else(|_| User::new_logged_out());
+  let user = auth_session.get_assert_user_from_session().unwrap_or_else(|_| User::new_logged_out());
   let (item, (comments, total_comments)) = tokio::try_join!(
     db::queries::items::get_assert_item(&state.pool, id),
     db::queries::comments::get_comments_page(&state.pool, id, page, user.show_dead),

--- a/api/src/routes/items/get.rs
+++ b/api/src/routes/items/get.rs
@@ -32,7 +32,7 @@ pub async fn get_item(
 
   let user = auth_session.get_user_from_session().unwrap_or_else(|_| User::new_logged_out());
   let (item, (comments, total_comments)) = tokio::try_join!(
-    db::queries::items::get_item(&state.pool, id),
+    db::queries::items::get_assert_item(&state.pool, id),
     db::queries::comments::get_comments_page(&state.pool, id, page, user.show_dead),
   )?;
 
@@ -44,7 +44,6 @@ pub async fn get_item(
   } else {
     // Authenticated user
     // get user's itemVotes, itemFavorites, itemHiddens, and commentVotes, and update item_response
-    // accordingly
     //
     // let (item_votes, item_favorites, item_hiddens, comment_votes) = tokio::try_join!(todo)
     Ok(Json(get_item_response))

--- a/api/src/routes/items/get.rs
+++ b/api/src/routes/items/get.rs
@@ -12,18 +12,20 @@ use super::*;
   )]
 /// Get item.
 ///
+/// If user is authenticated, ...todo
 ///
-///
-/// ref get_public: https://github.com/thor314/zkhn/blob/main/rest-api/routes/users/api.js#L223
-/// ref get_private: https://github.com/thor314/zkhn/blob/main/rest-api/routes/users/api.js#L244
-pub async fn get_item_simple(
+/// ref: https://github.com/thor314/zkhn/blob/main/rest-api/routes/items/api.js#L92
+pub async fn get_item(
   State(state): State<SharedState>,
   Path(id): Path<Uuid>,
-  auth_session: AuthSession, // todo(auth)
+  auth_session: AuthSession,
 ) -> ApiResult<Json<Item>> {
-  debug!("get_item called with id: {id}");
-  let pool = &state.pool;
-  // username.validate(&())?;
+  trace!("get_item called with id: {id}");
+  let is_authenticated = auth_session.is_authenticated_and_not_banned();
+  // mark show_dead_comments
+  // create comments query
+  // get item, comments, total comments number
+  //
   // let user = db::queries::users::get_item(pool, &)
   //   .await?
   //   .ok_or(ApiError::DbEntryNotFound("that user does not exist".to_string()))?;

--- a/api/src/routes/items/get.rs
+++ b/api/src/routes/items/get.rs
@@ -3,18 +3,16 @@ use super::*;
 #[utoipa::path(
   get,
   path = "/items/{id}",
-  params( ("username" = String, Path, example = "alice") ),
+  params( ("id" = String, Path, example = Uuid::new_v4) ),
   responses(
-    // todo(auth) auth error
-    // (status = 401, description = "Unauthorized"),
     (status = 422, description = "Invalid id"),
     (status = 404, description = "User not found"),
-    (status = 200, description = "Success", body = User),// todo(define reduced UserResponse body)
+    (status = 200, description = "Success", body = GetItemResponse),// todo(define reduced UserResponse body)
   ),
   )]
 /// Get item.
-///
-/// todo(auth): currently, we return the whole item. We actually want to return other stuff.
+/// 
+/// 
 ///
 /// ref get_public: https://github.com/thor314/zkhn/blob/main/rest-api/routes/users/api.js#L223
 /// ref get_private: https://github.com/thor314/zkhn/blob/main/rest-api/routes/users/api.js#L244

--- a/api/src/routes/items/mod.rs
+++ b/api/src/routes/items/mod.rs
@@ -33,5 +33,6 @@ pub fn items_router(state: SharedState) -> Router {
   Router::new()
     .route("/:id", routing::get(get::get_item))
     .route("/", routing::post(post::create_item))
+    .route("/vote", routing::post(post::vote_item))
     .with_state(state)
 }

--- a/api/src/routes/items/mod.rs
+++ b/api/src/routes/items/mod.rs
@@ -18,13 +18,12 @@ use db::{
 use garde::Validate;
 pub use payload::*;
 pub use response::*;
-use tracing::{debug, info, warn};
+use tracing::{debug, info, trace, warn};
 use uuid::Uuid;
 
 use super::SharedState;
-use crate::auth::AuthSession;
 use crate::{
-  // auth::{self, assert_authenticated},
+  auth::{AuthSession, AuthenticationExt},
   error::ApiError,
   ApiResult,
 };
@@ -32,7 +31,7 @@ use crate::{
 /// Router to be mounted at "/items"
 pub fn items_router(state: SharedState) -> Router {
   Router::new()
-    .route("/:id", routing::get(get::get_item_simple))
+    .route("/:id", routing::get(get::get_item))
     .route("/", routing::post(post::create_item))
     .with_state(state)
 }

--- a/api/src/routes/items/payload.rs
+++ b/api/src/routes/items/payload.rs
@@ -18,9 +18,9 @@ pub struct ItemPayload {
   #[garde(skip)]
   is_text:             bool,
   // todo: could turn this to an enum
-  #[garde(skip)] // todo(itemcontent)
+  #[garde(skip)] // todo(validate)
   text_or_url_content: String,
-  #[garde(skip)] // todo(item_category)
+  #[garde(skip)] // todo(validate)
   item_category: String,
 }
 
@@ -50,18 +50,16 @@ impl ItemPayload {
 
   /// convenience method for testing
   pub fn new(
-    username: &str,
     title: &str,
     item_type: &str,
     is_text: bool,
     text_or_url_content: &str,
     item_category: &str,
   ) -> ApiResult<Self> {
-    let username = Username(username.to_string());
-    let title = Title(title.to_string());
-    let item_type = item_type.to_string();
-    let text_or_url_content = text_or_url_content.to_string();
-    let item_category = item_category.to_string();
+    let title = title.into();
+    let item_type = item_type.into();
+    let text_or_url_content = text_or_url_content.into();
+    let item_category = item_category.into();
 
     let item_payload = Self { title, item_type, is_text, text_or_url_content, item_category };
     item_payload.validate(&())?;

--- a/api/src/routes/items/payload.rs
+++ b/api/src/routes/items/payload.rs
@@ -5,13 +5,14 @@ use db::{
 use garde::Validate;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
+use uuid::Uuid;
 
 use crate::ApiResult;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Validate, ToSchema)]
 #[serde(rename_all = "camelCase")]
-#[schema(default = ItemPayload::default, example=ItemPayload::default)]
-pub struct ItemPayload {
+#[schema(default = CreateItemPayload::default, example=CreateItemPayload::default)]
+pub struct CreateItemPayload {
   #[garde(dive)]
   pub title:           Title,
   #[garde(skip)] // todo(itemtype)
@@ -25,7 +26,7 @@ pub struct ItemPayload {
   item_category: String,
 }
 
-impl Default for ItemPayload {
+impl Default for CreateItemPayload {
   fn default() -> Self {
     Self {
       title:               Title::default(),
@@ -37,7 +38,7 @@ impl Default for ItemPayload {
   }
 }
 
-impl ItemPayload {
+impl CreateItemPayload {
   pub async fn into_item(self, username: Username) -> Item {
     Item::new(
       username,
@@ -66,4 +67,27 @@ impl ItemPayload {
     item_payload.validate(&())?;
     Ok(item_payload)
   }
+}
+
+/// A payload for voting on an item or comment
+#[derive(Default, Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[schema(default = VotePayload::default, example=VotePayload::default)]
+#[serde(rename_all = "camelCase")]
+pub struct VotePayload {
+  pub id:   Uuid,
+  pub vote: VotePayloadEnum,
+}
+impl VotePayload {
+  pub fn new(id: Uuid, vote: VotePayloadEnum) -> Self { Self { id, vote } }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum VotePayloadEnum {
+  Upvote,
+  Downvote,
+  Unvote,
+}
+impl Default for VotePayloadEnum {
+  fn default() -> Self { Self::Unvote }
 }

--- a/api/src/routes/items/post.rs
+++ b/api/src/routes/items/post.rs
@@ -1,33 +1,32 @@
+use tracing::trace;
+
 use super::*;
+use crate::auth::AuthenticationExt;
 
 #[utoipa::path(
   post,
   path = "/items",
   request_body = ItemPayload,
-  params( ("username" = String, Path, example = "alice") ),
   responses(
-    // todo(auth) auth error
     (status = 401, description = "Unauthorized"),
+    (status = 403, description = "Forbidden"),
     (status = 422, description = "Invalid Payload"),
     (status = 409, description = "Duplication Conflict"),
-    (status = 200, description = "Success"), 
+    (status = 200),
   ),
   )]
+/// Create a new item
 pub async fn create_item(
   State(state): State<SharedState>,
   auth_session: AuthSession,
   Json(payload): Json<ItemPayload>,
 ) -> ApiResult<StatusCode> {
-  debug!(
-    "create_item called with payload: {payload:?} by: {}",
-    auth_session.user.as_ref().map(|u| &u.0.username.0).unwrap_or(&"".into())
-  );
-  // todo(error handling): error passing like this should probably be a defined method for DRY
-  let user = auth_session.user.ok_or(ApiError::UnauthorizedPleaseLogin)?.0.clone();
+  trace!("create_item called with payload: {payload:?}");
   payload.validate(&())?;
-  let item: Item = payload.into_item(user.username).await;
+  let user = auth_session.get_user_from_session()?;
+  let item = payload.into_item(user.username).await;
   db::queries::items::create_item(&state.pool, &item).await?;
 
-  info!("created item: {item:?}");
+  debug!("created item: {item:?}");
   Ok(StatusCode::OK)
 }

--- a/api/src/routes/items/post.rs
+++ b/api/src/routes/items/post.rs
@@ -16,6 +16,8 @@ use crate::auth::AuthenticationExt;
   ),
   )]
 /// Create a new item
+///
+/// ref: https://github.com/thor314/zkhn/blob/main/rest-api/routes/items/api.js#L39
 pub async fn create_item(
   State(state): State<SharedState>,
   auth_session: AuthSession,

--- a/api/src/routes/items/post.rs
+++ b/api/src/routes/items/post.rs
@@ -1,18 +1,15 @@
-use tracing::trace;
-
 use super::*;
-use crate::auth::AuthenticationExt;
 
 #[utoipa::path(
   post,
   path = "/items",
-  request_body = ItemPayload,
+  request_body = CreateItemPayload,
   responses(
     (status = 401, description = "Unauthorized"),
     (status = 403, description = "Forbidden"),
     (status = 422, description = "Invalid Payload"),
     (status = 409, description = "Duplication Conflict"),
-    (status = 200),
+    (status = 200, body = Uuid),
   ),
   )]
 /// Create a new item
@@ -21,8 +18,8 @@ use crate::auth::AuthenticationExt;
 pub async fn create_item(
   State(state): State<SharedState>,
   auth_session: AuthSession,
-  Json(payload): Json<ItemPayload>,
-) -> ApiResult<StatusCode> {
+  Json(payload): Json<CreateItemPayload>,
+) -> ApiResult<Json<Uuid>> {
   trace!("create_item called with payload: {payload:?}");
   payload.validate(&())?;
   let user = auth_session.get_user_from_session()?;
@@ -30,5 +27,48 @@ pub async fn create_item(
   db::queries::items::create_item(&state.pool, &item).await?;
 
   debug!("created item: {item:?}");
-  Ok(StatusCode::OK)
+  Ok(Json(item.id))
+}
+
+
+#[utoipa::path(
+  post,
+  path = "/items/vote",
+  request_body = VotePayload,
+  responses(
+    (status = 401, description = "Unauthorized"),
+    (status = 403, description = "Forbidden"),
+    (status = 422, description = "Invalid Payload"),
+    (status = 409, description = "Duplication Conflict"),
+    (status = 200, body = Uuid),
+  ),
+  )]
+/// Submit an {up,down,un}vote on an item.
+/// 
+/// Return Conflict if the user has already voted identically on the item.
+///
+/// ref: https://github.com/thor314/zkhn/blob/main/rest-api/routes/items/api.js#L259
+/// ref: https://github.com/thor314/zkhn/blob/main/rest-api/routes/items/index.js#L77
+pub async fn vote_item(
+  State(state): State<SharedState>,
+  auth_session: AuthSession,
+  Json(payload): Json<VotePayload>,
+) -> ApiResult<Json<Uuid>> {
+  trace!("vote_item called with payload: {payload:?}");
+  let user = auth_session.get_user_from_session()?;
+  let (item, vote) = tokio::try_join!(
+    db::queries::items::get_assert_item(&state.pool, payload.id),
+    db::queries::user_votes::get_vote(&state.pool, &user.username, payload.id),
+  )?;
+  // note - diverge from reference, allow submitting user to vote on their own item
+  // if vote.matches(&payload}) { return Err(ApiError::Conflict); }
+
+  // todo(vote): insert the new vote
+  // let vote = db::models::user_votes::UserVote::new(&user.username, &payload);
+  // db::queries::user_votes::insert_vote(&state.pool, &vote);
+  // todo(item points)
+  // todo(karma)
+
+  debug!("vote submitted");
+  Ok(Json(item.id))
 }

--- a/api/src/routes/items/post.rs
+++ b/api/src/routes/items/post.rs
@@ -30,7 +30,6 @@ pub async fn create_item(
   Ok(Json(item.id))
 }
 
-
 #[utoipa::path(
   post,
   path = "/items/vote",
@@ -44,7 +43,7 @@ pub async fn create_item(
   ),
   )]
 /// Submit an {up,down,un}vote on an item.
-/// 
+///
 /// Return Conflict if the user has already voted identically on the item.
 ///
 /// ref: https://github.com/thor314/zkhn/blob/main/rest-api/routes/items/api.js#L259

--- a/api/src/routes/items/post.rs
+++ b/api/src/routes/items/post.rs
@@ -22,7 +22,7 @@ pub async fn create_item(
 ) -> ApiResult<Json<Uuid>> {
   trace!("create_item called with payload: {payload:?}");
   payload.validate(&())?;
-  let user = auth_session.get_user_from_session()?;
+  let user = auth_session.get_assert_user_from_session()?;
   let item = payload.into_item(user.username).await;
   db::queries::items::create_item(&state.pool, &item).await?;
 
@@ -54,7 +54,7 @@ pub async fn vote_item(
   Json(payload): Json<VotePayload>,
 ) -> ApiResult<Json<Uuid>> {
   trace!("vote_item called with payload: {payload:?}");
-  let user = auth_session.get_user_from_session()?;
+  let user = auth_session.get_assert_user_from_session()?;
   let (item, vote) = tokio::try_join!(
     db::queries::items::get_assert_item(&state.pool, payload.id),
     db::queries::user_votes::get_vote(&state.pool, &user.username, payload.id),

--- a/api/src/routes/items/response.rs
+++ b/api/src/routes/items/response.rs
@@ -5,8 +5,7 @@ use db::{
 use serde::{Deserialize, Serialize};
 use utoipa::{OpenApi, ToSchema};
 
-const COMMENTS_PER_PAGE: usize = 10; // todo(config)
-
+use crate::COMMENTS_PER_PAGE;
 #[derive(Debug, Serialize, Deserialize, ToSchema, Default)]
 #[schema(default = GetItemResponse::default, example=GetItemResponse::default)]
 pub struct GetItemResponse {

--- a/api/src/routes/items/response.rs
+++ b/api/src/routes/items/response.rs
@@ -1,36 +1,23 @@
-use db::{models::item::Item, AuthToken, Timestamp};
+use db::{
+  models::{comment::Comment, item::Item},
+  AuthToken, Timestamp, Username,
+};
 use serde::{Deserialize, Serialize};
 use utoipa::{OpenApi, ToSchema};
 
-// // success: true,
-// // item: item,
-// // comments: comments,
-// // isMoreComments:
-// //   totalNumOfComments >
-// //   (page - 1) * config.commentsPerPage + config.commentsPerPage
-// //     ? true
-// //     : false,
-// #[derive(Debug, Serialize, Deserialize, ToSchema)]
-// #[schema(default = ItemResponse::default, example=ItemResponse::default)]
-// pub struct ItemResponse {
-//   // todo(refactor): success is redundant
-//   pub success: bool,
-//   // item:
-//   // pub username: Itemname,
-//   // pub auth_token: AuthToken,
-//   // pub auth_token_expiration_timestamp: Timestamp,
-// }
+const COMMENTS_PER_PAGE: usize = 10; // todo(config)
 
-// impl Default for ItemResponse {
-//   fn default() -> Self { Self {} }
-// }
+#[derive(Debug, Serialize, Deserialize, ToSchema, Default)]
+#[schema(default = GetItemResponse::default, example=GetItemResponse::default)]
+pub struct GetItemResponse {
+  pub item:             Item,
+  pub comments:         Vec<Comment>,
+  pub is_more_comments: bool,
+}
 
-// impl ItemResponse {
-//   pub(crate) fn new(user: Item, auth_token: AuthToken, auth_token_expiration: Timestamp) -> Self
-// {     Self {}
-//   }
-// }
-
-// impl From<Item> for ItemResponse {
-//   fn from(user: Item) -> Self { Self {} }
-// }
+impl GetItemResponse {
+  pub fn new(item: Item, comments: Vec<Comment>, page: usize) -> Self {
+    let is_more_comments = comments.len() > page * COMMENTS_PER_PAGE;
+    Self { item, comments, is_more_comments }
+  }
+}

--- a/api/src/routes/mod.rs
+++ b/api/src/routes/mod.rs
@@ -5,7 +5,7 @@ use tower_sessions_sqlx_store::PostgresStore;
 use tracing::debug;
 
 use self::{openapi::docs_router, users::users_router};
-use crate::auth::MyAuthLayer;
+use crate::{auth::MyAuthLayer, items_router};
 
 // pub mod so that payloads and responses can be accessed by integration tests
 pub mod comments;
@@ -28,6 +28,7 @@ pub(crate) fn routes(pool: DbPool) -> Router {
     .route("/health", routing::get(health))
     .nest("/docs", docs_router())
     .nest("/users", users_router(state.clone()))
+    .nest("/items", items_router(state.clone()))
 }
 
 /// shared state for handlers to access via the State Extractor

--- a/api/src/routes/openapi.rs
+++ b/api/src/routes/openapi.rs
@@ -26,9 +26,9 @@ use utoipa::OpenApi;
 use utoipa_rapidoc::RapiDoc;
 use utoipauto::utoipauto;
 
-use super::users::{get::*, post::*, put::*, *};
 // use super::items::{get::*, post::*, put::*, *};
 use super::items::*;
+use super::users::{get::*, post::*, put::*, *};
 
 /// router fragment supplying OpenAPI documentation and ui routes
 /// View rapidoc documentation page at: http://localhost:3000/docs/rapidoc
@@ -46,8 +46,8 @@ pub(super) fn docs_router() -> Router {
   // Schemas that may be returned in the body by the api.
   components(schemas(
     User, UserUpdatePayload, ChangePasswordPayload, UserPayload,
-    CredentialsPayload, GetUserResponse, CreateUserResponse, AuthenticateUserResponse, 
-    CreateItemPayload, 
+    CredentialsPayload, GetUserResponse, CreateUserResponse, AuthenticateUserResponse,
+    CreateItemPayload,
     GetItemResponse,
     VotePayload, ))
   // runtime modification, e.g. for jwt: https://docs.rs/utoipa/latest/utoipa/trait.Modify.html

--- a/api/src/routes/openapi.rs
+++ b/api/src/routes/openapi.rs
@@ -27,6 +27,8 @@ use utoipa_rapidoc::RapiDoc;
 use utoipauto::utoipauto;
 
 use super::users::{get::*, post::*, put::*, *};
+// use super::items::{get::*, post::*, put::*, *};
+use super::items::*;
 
 /// router fragment supplying OpenAPI documentation and ui routes
 /// View rapidoc documentation page at: http://localhost:3000/docs/rapidoc
@@ -42,8 +44,12 @@ pub(super) fn docs_router() -> Router {
 #[openapi(
   info(description = "API documentation for ZKHN"),
   // Schemas that may be returned in the body by the api.
-  components(schemas(User, UserUpdatePayload, ChangePasswordPayload, UserPayload,
-    CredentialsPayload, GetUserResponse, CreateUserResponse, AuthenticateUserResponse))
+  components(schemas(
+    User, UserUpdatePayload, ChangePasswordPayload, UserPayload,
+    CredentialsPayload, GetUserResponse, CreateUserResponse, AuthenticateUserResponse, 
+    CreateItemPayload, 
+    GetItemResponse,
+    VotePayload, ))
   // runtime modification, e.g. for jwt: https://docs.rs/utoipa/latest/utoipa/trait.Modify.html
   // low-priority, but could gate moderator methods with an auth token.
   // modifiers(..) 

--- a/api/src/routes/openapi.rs
+++ b/api/src/routes/openapi.rs
@@ -45,7 +45,7 @@ pub(super) fn docs_router() -> Router {
   info(description = "API documentation for ZKHN"),
   // Schemas that may be returned in the body by the api.
   components(schemas(
-    User, UserUpdatePayload, ChangePasswordPayload, UserPayload,
+    User, UserUpdatePayload, ChangePasswordPayload, CreateUserPayload,
     CredentialsPayload, GetUserResponse, CreateUserResponse, AuthenticateUserResponse,
     CreateItemPayload,
     GetItemResponse,

--- a/api/src/routes/users/mod.rs
+++ b/api/src/routes/users/mod.rs
@@ -33,8 +33,6 @@ pub(super) fn users_router(state: SharedState) -> Router {
 }
 
 pub(super) mod get {
-  use serde_json::json;
-
   use super::*;
 
   #[utoipa::path(

--- a/api/src/routes/users/mod.rs
+++ b/api/src/routes/users/mod.rs
@@ -59,7 +59,7 @@ pub(super) mod get {
     trace!("get_user called with username: {username}");
     username.validate(&())?;
     let user = users::get_user(&state.pool, &username).await?;
-    let is_authenticated = auth_session.is_authenticated_and_not_banned(&username);
+    let is_authenticated = auth_session.is_username_authenticated_and_not_banned(&username);
     let user_response = GetUserResponse::new(user, is_authenticated);
 
     debug!("user response: {user_response:?}");

--- a/api/src/routes/users/response.rs
+++ b/api/src/routes/users/response.rs
@@ -68,6 +68,7 @@ impl GetUserResponse {
     }
   }
 }
+
 #[derive(Debug, Serialize, Deserialize, ToSchema, Default)]
 #[schema(default = AuthenticateUserResponse::default, example=AuthenticateUserResponse::default)]
 pub struct AuthenticateUserResponse {

--- a/api/src/routes/users/response.rs
+++ b/api/src/routes/users/response.rs
@@ -5,8 +5,6 @@ use utoipa::ToSchema;
 #[derive(Debug, Serialize, Deserialize, ToSchema, Default)]
 #[schema(default = CreateUserResponse::default, example=CreateUserResponse::default)]
 pub struct CreateUserResponse {
-  // hack(refactor): success is redundant
-  pub success: bool,
   pub username: Username,
   pub auth_token: AuthToken,
   pub auth_token_expiration_timestamp: Timestamp,
@@ -15,7 +13,6 @@ pub struct CreateUserResponse {
 impl CreateUserResponse {
   pub(crate) fn new(user: User, auth_token: AuthToken, auth_token_expiration: Timestamp) -> Self {
     Self {
-      success: true,
       username: user.username,
       auth_token,
       auth_token_expiration_timestamp: auth_token_expiration,
@@ -26,7 +23,6 @@ impl CreateUserResponse {
 impl From<User> for CreateUserResponse {
   fn from(user: User) -> Self {
     Self {
-      success: true,
       username: user.username,
       auth_token: user.auth_token.unwrap_or_default(),
       auth_token_expiration_timestamp: user
@@ -72,8 +68,6 @@ impl GetUserResponse {
 #[derive(Debug, Serialize, Deserialize, ToSchema, Default)]
 #[schema(default = AuthenticateUserResponse::default, example=AuthenticateUserResponse::default)]
 pub struct AuthenticateUserResponse {
-  // hack(redundant)
-  pub success:        bool,
   pub username:       Username,
   pub banned:         bool,
   pub karma:          i32,
@@ -86,7 +80,6 @@ pub struct AuthenticateUserResponse {
 impl AuthenticateUserResponse {
   pub fn new(user: User) -> Self {
     Self {
-      success:        true,
       username:       user.username,
       banned:         user.banned,
       karma:          user.karma,

--- a/db/migrations/20240402185206_items.up.sql
+++ b/db/migrations/20240402185206_items.up.sql
@@ -13,6 +13,6 @@ CREATE TABLE items (
     comment_count INT DEFAULT 0 NOT NULL, 
     -- todo(sql-enums)
     item_category TEXT NOT NULL DEFAULT 'other',
-    created TIMESTAMP WITH TIME ZONE NOT NULL,
+    created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
     dead BOOLEAN DEFAULT false NOT NULL
 );

--- a/db/src/error.rs
+++ b/db/src/error.rs
@@ -16,11 +16,6 @@ pub enum DbError {
   #[error("Sqlx error: {0}")]
   Sqlx(String),
 
-  // user error
-  /// Library error, i.e. Hashing failed (hope to catch in password validation stage)
-  #[error("Password error: {0}")]
-  PwError(String),
-
   // database errors
   #[error("Entry already exists in db: {0}")]
   UniqueViolation(String),
@@ -33,7 +28,7 @@ pub enum DbError {
   #[error("Other db error: {0}")]
   Other(String),
 
-  #[error("Entry not found in db")]
+  #[error("Entry not found in db: {0}")]
   NotFound(String),
 }
 
@@ -51,12 +46,4 @@ impl From<sqlx::Error> for DbError {
       _ => DbError::Sqlx(err.to_string()),
     }
   }
-}
-
-impl From<argon2::password_hash::Error> for DbError {
-  fn from(err: argon2::password_hash::Error) -> Self { DbError::PwError(err.to_string()) }
-}
-
-impl From<argon2::Error> for DbError {
-  fn from(err: argon2::Error) -> Self { DbError::PwError(err.to_string()) }
 }

--- a/db/src/models/comment.rs
+++ b/db/src/models/comment.rs
@@ -11,7 +11,7 @@ use crate::{error::DbError, utils::now, CommentText, DbResult, Timestamp, Title,
 const MIN_POINTS: i32 = -4;
 
 /// Comments on a post
-#[derive(sqlx::FromRow, Debug, Serialize, Encode, Clone)]
+#[derive(sqlx::FromRow, Debug, Serialize, Encode, Clone, Deserialize)]
 pub struct Comment {
   /// the unique identifier given to each comment in the form of a randomly generated string
   pub id:                Uuid, // Assuming UUIDs for unique identifiers, common in SQL databases

--- a/db/src/models/user.rs
+++ b/db/src/models/user.rs
@@ -46,7 +46,7 @@ pub struct User {
 impl Default for User {
   fn default() -> Self {
     User {
-      username: Username("alice".to_string()),
+      username: "alice".into(),
       password_hash: PasswordHash("password".to_string()),
       auth_token: None,
       auth_token_expiration: None,
@@ -100,6 +100,13 @@ impl User {
   //     created: now(),
   //   }
   // }
+
+  /// Create a mock User
+  /// 
+  /// Use in cases where we want the default user metadata, but don't have a authenticated user
+  /// 
+  /// backlog: kindof a dumb footgun
+  pub fn new_logged_out() -> Self { Self { username: "".into(), ..Default::default() } }
 }
 
 // explicitly redact sensitive info

--- a/db/src/models/user.rs
+++ b/db/src/models/user.rs
@@ -102,9 +102,9 @@ impl User {
   // }
 
   /// Create a mock User
-  /// 
+  ///
   /// Use in cases where we want the default user metadata, but don't have a authenticated user
-  /// 
+  ///
   /// backlog: kindof a dumb footgun
   pub fn new_logged_out() -> Self { Self { username: "".into(), ..Default::default() } }
 }

--- a/db/src/queries/comments.rs
+++ b/db/src/queries/comments.rs
@@ -6,20 +6,30 @@ use sqlx::{Pool, Postgres, QueryBuilder, Transaction};
 use uuid::Uuid;
 
 use crate::{
-  error::DbError, models::{
+  error::DbError,
+  models::{
     comment::{self, Comment},
     item::Item,
     user_vote::{UserVote, VoteState},
-  }, utils::now, CommentText, DbPool, DbResult, Page, Title, Username
+  },
+  utils::now,
+  CommentText, DbPool, DbResult, Page, Title, Username,
 };
 
-pub async fn get_comments_page_for_item_id(
+pub async fn get_comments_page(
   pool: &DbPool,
   item_id: Uuid,
-  show_dead_comments: bool,
   page: Page,
-) -> DbResult<Vec<Comment>> {
+  show_dead_comments: bool, // backlog
+) -> DbResult<(Vec<Comment>, usize)> {
   // todo(comments)
+  //
+  // mirror in query:
+  // .sort({ points: -1, created: -1 })
+  // .skip((page - 1) * config.commentsPerPage)
+  // .limit(config.commentsPerPage)
+  //
+
   // let comments: Vec<Comment> = sqlx::query_as!(
   //   Comment,
   //   "SELECT
@@ -41,9 +51,10 @@ pub async fn get_comments_page_for_item_id(
   // )
   // .fetch_all(pool)
   // .await?;
-  let comments = vec![]; 
+  let comments = vec![];
+  let total_comments = 0;
 
-  Ok(comments)
+  Ok((comments, total_comments))
 }
 
 // pub async fn get_comment(pool: &DbPool, comment_id: Uuid) -> DbResult<Option<Comment>> {

--- a/db/src/queries/comments.rs
+++ b/db/src/queries/comments.rs
@@ -1,20 +1,50 @@
-// use std::collections::HashSet;
+use std::collections::HashSet;
 
-// use futures::future::join_all;
-// use rayon::prelude::*;
-// use sqlx::{Pool, Postgres, QueryBuilder, Transaction};
-// use uuid::Uuid;
+use futures::future::join_all;
+use rayon::prelude::*;
+use sqlx::{Pool, Postgres, QueryBuilder, Transaction};
+use uuid::Uuid;
 
-// use crate::{
-//   error::DbError,
-//   models::{
-//     comment::{self, Comment},
-//     item::Item,
-//     user_vote::{UserVote, VoteState},
-//   },
-//   utils::now,
-//   CommentText, DbPool, DbResult, Title, Username,
-// };
+use crate::{
+  error::DbError, models::{
+    comment::{self, Comment},
+    item::Item,
+    user_vote::{UserVote, VoteState},
+  }, utils::now, CommentText, DbPool, DbResult, Page, Title, Username
+};
+
+pub async fn get_comments_page_for_item_id(
+  pool: &DbPool,
+  item_id: Uuid,
+  show_dead_comments: bool,
+  page: Page,
+) -> DbResult<Vec<Comment>> {
+  // todo(comments)
+  // let comments: Vec<Comment> = sqlx::query_as!(
+  //   Comment,
+  //   "SELECT
+  //     id,
+  //     username as \"username: Username\",
+  //     parent_item_id,
+  //     parent_item_title as \"parent_item_title: Title\",
+  //     comment_text as \"comment_text: CommentText\",
+  //     is_parent,
+  //     root_comment_id,
+  //     parent_comment_id,
+  //     children_count,
+  //     points,
+  //     created,
+  //     dead
+  //   FROM comments WHERE parent_item_id = $1 AND dead = $2",
+  //   item_id,
+  //   show_dead_comments
+  // )
+  // .fetch_all(pool)
+  // .await?;
+  let comments = vec![]; 
+
+  Ok(comments)
+}
 
 // pub async fn get_comment(pool: &DbPool, comment_id: Uuid) -> DbResult<Option<Comment>> {
 //   sqlx::query_as!(

--- a/db/src/queries/items.rs
+++ b/db/src/queries/items.rs
@@ -43,7 +43,11 @@ pub async fn create_item(pool: &DbPool, item: &Item) -> DbResult<()> {
   Ok(())
 }
 
-pub async fn get_item(pool: &DbPool, item_id: Uuid) -> DbResult<Item> {
+pub async fn get_assert_item(pool: &DbPool, item_id: Uuid) -> DbResult<Item> {
+  get_item(pool, item_id).await?.ok_or(DbError::NotFound("item".into()))
+}
+
+pub async fn get_item(pool: &DbPool, item_id: Uuid) -> DbResult<Option<Item>> {
   sqlx::query_as!(
     Item,
     "SELECT
@@ -64,8 +68,8 @@ pub async fn get_item(pool: &DbPool, item_id: Uuid) -> DbResult<Item> {
     item_id
   )
   .fetch_optional(pool)
-  .await?
-  .ok_or(DbError::NotFound("item".into()))
+  .await
+  .map_err(DbError::from)
 }
 
 // pub async fn delete_item(pool: &DbPool, item_id: Uuid) -> DbResult<()> {

--- a/db/src/queries/items.rs
+++ b/db/src/queries/items.rs
@@ -43,30 +43,30 @@ pub async fn create_item(pool: &DbPool, item: &Item) -> DbResult<()> {
   Ok(())
 }
 
-// pub async fn get_item(pool: &DbPool, item_id: Uuid) -> DbResult<Option<Item>> {
-//   sqlx::query_as!(
-//     Item,
-//     "SELECT
-//       id,
-//       username as \"username: Username\",
-//       title as \"title: Title\",
-//       item_type,
-//       url,
-//       domain,
-//       text,
-//       points,
-//       score,
-//       comment_count,
-//       item_category,
-//       created,
-//       dead
-//     FROM items WHERE id = $1",
-//     item_id
-//   )
-//   .fetch_optional(pool)
-//   .await
-//   .map_err(DbError::from)
-// }
+pub async fn get_item(pool: &DbPool, item_id: Uuid) -> DbResult<Item> {
+  sqlx::query_as!(
+    Item,
+    "SELECT
+      id,
+      username as \"username: Username\",
+      title as \"title: Title\",
+      item_type,
+      url,
+      domain,
+      text,
+      points,
+      score,
+      comment_count,
+      item_category,
+      created,
+      dead
+    FROM items WHERE id = $1",
+    item_id
+  )
+  .fetch_optional(pool)
+  .await?
+  .ok_or(DbError::NotFound("item".into()))
+}
 
 // pub async fn delete_item(pool: &DbPool, item_id: Uuid) -> DbResult<()> {
 //   sqlx::query!("DELETE FROM items WHERE id = $1", item_id)

--- a/db/src/queries/user_votes.rs
+++ b/db/src/queries/user_votes.rs
@@ -7,6 +7,15 @@ use crate::{
   DbPool, DbResult, Username,
 };
 
+pub async fn get_assert_vote(pool: &DbPool, username: &Username, id: Uuid) -> DbResult<()> {
+  get_vote(pool, username, id).await?.ok_or(DbError::NotFound("vote".into()))
+}
+
+// todo(vote) + get_assert_vote
+pub async fn get_vote(pool: &DbPool, username: &Username, id: Uuid) -> DbResult<Option<()>> {
+  todo!()
+}
+
 // pub async fn get_user_vote_by_content_id(
 //   pool: &DbPool,
 //   username: &str,

--- a/db/src/types.rs
+++ b/db/src/types.rs
@@ -105,7 +105,7 @@ impl Default for ResetPasswordToken {
 #[repr(transparent)]
 pub struct Title(#[garde(ascii, length(min = 8, max = 100))] pub String);
 impl Default for Title {
-  fn default() -> Self { "title".into() }
+  fn default() -> Self { "item title".into() }
 }
 impl From<&str> for Title {
   fn from(s: &str) -> Self { Title(s.to_string()) }

--- a/db/src/types.rs
+++ b/db/src/types.rs
@@ -121,3 +121,16 @@ impl Default for CommentText {
 impl From<&str> for CommentText {
   fn from(s: &str) -> Self { CommentText(s.to_string()) }
 }
+
+// hack: does this need to be `Type`
+#[derive(Debug, Clone, Serialize, Deserialize, Type, Validate)]
+#[garde(transparent)]
+#[repr(transparent)]
+/// A page of comments or items
+pub struct Page(#[garde(range(min = 1, max = 1000))] pub i32);
+impl Default for Page {
+  fn default() -> Self { Self(1) }
+}
+impl From<i32> for Page {
+  fn from(n: i32) -> Self { Self(n) }
+}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -33,3 +33,4 @@ quickcheck       ="1.0"                                  # lowkey proptest suite
 quickcheck_macros="1"                                    # derive 
 reqwest = "0.12.2"
 serial_test = "3.0.0"
+uuid = { version = "1.8.0", features = ["v4"] }

--- a/server/tests/integration.rs
+++ b/server/tests/integration.rs
@@ -1,3 +1,7 @@
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![allow(dead_code)]
+
 use api::*;
 use reqwest::Client;
 use serial_test::serial;
@@ -9,8 +13,8 @@ pub const WEBSERVER_URL: &str = "http://localhost:8000";
 
 mod integration_utils;
 
-#[tokio::test]
-#[serial]
+// #[tokio::test]
+// #[serial]
 async fn user_crud() {
   let mut _child_guard = cargo_shuttle_run().await;
   let c = Client::builder().cookie_store(true).build().unwrap();
@@ -38,12 +42,12 @@ async fn user_crud() {
   send(&c, "", "GET", "users/alice", 200, "e").await;
 }
 
-// #[tokio::test]
-// #[serial]
-// async fn items_crud() {
-//   let mut _child_guard = cargo_shuttle_run().await;
-//   let c = Client::builder().cookie_store(true).build().unwrap();
-//   send(&c, UserPayload::default(), "POST", "users", 200, "1").await;
-//   send(&c, CredentialsPayload::default(), "POST", "users/login", 200, "2").await;
-//   // send(&c, )
-// }
+#[tokio::test]
+#[serial]
+async fn items_crud() {
+  let mut _child_guard = cargo_shuttle_run().await;
+  let c = Client::builder().cookie_store(true).build().unwrap();
+  send(&c, UserPayload::default(), "POST", "users", 200, "1").await;
+  send(&c, CredentialsPayload::default(), "POST", "users/login", 200, "2").await;
+  // send(&c, )
+}

--- a/server/tests/integration.rs
+++ b/server/tests/integration.rs
@@ -13,8 +13,8 @@ pub const WEBSERVER_URL: &str = "http://localhost:8000";
 
 mod integration_utils;
 
-#[tokio::test]
-#[serial]
+// #[tokio::test]
+// #[serial]
 async fn user_crud() {
   let mut _child_guard = cargo_shuttle_run().await;
   let c = Client::builder().cookie_store(true).build().unwrap();

--- a/server/tests/integration.rs
+++ b/server/tests/integration.rs
@@ -49,5 +49,13 @@ async fn items_crud() {
   let c = Client::builder().cookie_store(true).build().unwrap();
   send(&c, UserPayload::default(), "POST", "users", 200, "1").await;
   send(&c, CredentialsPayload::default(), "POST", "users/login", 200, "2").await;
-  // send(&c, )
+  let id: uuid::Uuid =
+    send(&c, CreateItemPayload::default(), "POST", "items", 200, "3").await.json().await.unwrap();
+  send(&c, "", "GET", &format!("items/{id}?1"), 200, "4").await;
+  send(&c, "", "GET", &format!("items/{id}?2"), 200, "5").await;
+  send(&c, "", "GET", &format!("items/{id}?2"), 200, "6").await;
+  send(&c, "", "GET", &format!("items/{id}?2"), 200, "7").await;
+  let upvote = VotePayload::new(id, VotePayloadEnum::Upvote);
+  // let downvote = VotePayload::new(id, VotePayloadEnum::Downvote);
+  send(&c, upvote, "POST", "items/vote", 200, "8").await;
 }

--- a/server/tests/integration.rs
+++ b/server/tests/integration.rs
@@ -13,23 +13,22 @@ pub const WEBSERVER_URL: &str = "http://localhost:8000";
 
 mod integration_utils;
 
-// #[tokio::test]
-// #[serial]
+#[tokio::test]
+#[serial]
 async fn user_crud() {
   let mut _child_guard = cargo_shuttle_run().await;
   let c = Client::builder().cookie_store(true).build().unwrap();
 
   send(&c, "", "GET", "users/alice", 404, "00").await;
-  send(&c, "", "GET", "users/authenticate/alice", 401, "11").await;
-  send(&c, UserPayload::default(), "POST", "users", 200, "1").await;
-  send(&c, "", "GET", "users/authenticate/alice", 401, "44").await;
-  send(&c, UserPayload::default(), "POST", "users", 409, "2").await;
+  send(&c, "", "GET", "users/authenticate", 401, "11").await;
+  send(&c, CreateUserPayload::default(), "POST", "users", 200, "1").await;
+  send(&c, "", "GET", "users/authenticate", 401, "44").await;
+  send(&c, CreateUserPayload::default(), "POST", "users", 409, "2").await;
   send(&c, CredentialsPayload::default(), "POST", "users/login", 200, "3").await;
-  send(&c, "", "GET", "users/authenticate/alice", 200, "22").await;
-  send(&c, "", "GET", "users/authenticate/bob", 403, "33").await;
+  send(&c, "", "GET", "users/authenticate", 200, "22").await;
   send(&c, CredentialsPayload::default(), "POST", "users/login", 200, "4").await;
   send(&c, CredentialsPayload::default(), "POST", "users/logout", 200, "5").await;
-  send(&c, "", "GET", "users/authenticate/alice", 401, "44").await;
+  send(&c, "", "GET", "users/authenticate", 401, "44").await;
   send(&c, CredentialsPayload::default(), "POST", "users/logout", 200, "6").await;
   send(&c, CredentialsPayload::default(), "POST", "users/login", 200, "7").await;
   send(&c, UserUpdatePayload::default(), "PUT", "users", 200, "8").await;
@@ -47,14 +46,14 @@ async fn user_crud() {
 async fn items_crud() {
   let mut _child_guard = cargo_shuttle_run().await;
   let c = Client::builder().cookie_store(true).build().unwrap();
-  send(&c, UserPayload::default(), "POST", "users", 200, "1").await;
+  send(&c, CreateUserPayload::default(), "POST", "users", 200, "1").await;
   send(&c, CredentialsPayload::default(), "POST", "users/login", 200, "2").await;
   let id: uuid::Uuid =
     send(&c, CreateItemPayload::default(), "POST", "items", 200, "3").await.json().await.unwrap();
   send(&c, "", "GET", &format!("items/{id}?1"), 200, "4").await;
   send(&c, "", "GET", &format!("items/{id}?2"), 200, "5").await;
-  send(&c, "", "GET", &format!("items/{id}?2"), 200, "6").await;
-  send(&c, "", "GET", &format!("items/{id}?2"), 200, "7").await;
+  // send(&c, "", "GET", &format!("items/{id}?2"), 200, "6").await;
+  // send(&c, "", "GET", &format!("items/{id}?2"), 200, "7").await;
   let upvote = VotePayload::new(id, VotePayloadEnum::Upvote);
   // let downvote = VotePayload::new(id, VotePayloadEnum::Downvote);
   send(&c, upvote, "POST", "items/vote", 200, "8").await;

--- a/server/tests/integration_utils.rs
+++ b/server/tests/integration_utils.rs
@@ -42,7 +42,7 @@ pub async fn send(
   path: &str,
   status: u16,
   tag: &str,
-) {
+) -> Response {
   let res = match method {
     "POST" => client.post(format!("{}/{}", WEBSERVER_URL, path)).send_json(payload).await,
     "PUT" => client.put(format!("{}/{}", WEBSERVER_URL, path)).send_json(payload).await,
@@ -52,6 +52,7 @@ pub async fn send(
     _ => panic!("Invalid method"),
   };
   assert_eq!(res.status(), status, "Test {} failed", tag);
+  res
 }
 
 trait ClientExt {

--- a/server/tests/integration_utils.rs
+++ b/server/tests/integration_utils.rs
@@ -6,6 +6,7 @@ pub const WEBSERVER_URL: &str = "http://localhost:8000";
 
 /// Run the shuttle server
 pub async fn cargo_shuttle_run() -> ChildGuard {
+  tracing_subscriber_setup();
   db_setup();
   server_cleanup();
   rm_docker_claude();
@@ -127,4 +128,19 @@ fn _rm_docker_gemini() {
     let container_id = String::from_utf8(output.stdout).unwrap().trim().to_string();
     Command::new("docker").args(["rm", "-f", &container_id]).output().unwrap();
   }
+}
+
+fn tracing_subscriber_setup() {
+  let filter = tracing_subscriber::EnvFilter::from_default_env()
+    // .add_directive(LevelFilter::DEBUG.into())
+    .add_directive("sqlx=info".parse().unwrap())
+    // .add_directive("tower_http=debug".parse().unwrap())
+    // .add_directive("tower_sessions=debug".parse().unwrap())
+    // .add_directive("axum_login=debug".parse().unwrap())
+    .add_directive("axum_login=info".parse().unwrap())
+    .add_directive("h2=info".parse().unwrap())
+    .add_directive("api=info".parse().unwrap())
+    .add_directive("db=info".parse().unwrap())
+    .add_directive("server=info".parse().unwrap());
+  tracing_subscriber::fmt().with_env_filter(filter).with_test_writer().init();
 }


### PR DESCRIPTION
- adjust int tests
- auth modifications to create_item
- get_item_response
- kill success in user responses
- twiddling get item and auth
- mock get_item
- minor db reduction lint
- page type
- get_item proto
- vote_item written
- cf
- authenticate modified, authentication trait simplified
- tracing subscriber setup in integration tests
- pause user crud integration test and include items in router
- pause - return to debugging items momentarily
